### PR TITLE
[BE_강수민] 관리자 페이지 생성

### DIFF
--- a/src/main/java/com/team25/backend/controller/AdminController.java
+++ b/src/main/java/com/team25/backend/controller/AdminController.java
@@ -5,6 +5,8 @@ import com.team25.backend.service.AdminService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -22,5 +24,10 @@ public class AdminController {
         model.addAttribute("usersWithManagers", usersWithManagers);
         return "admin/list";
     }
-}
 
+    @PostMapping("/admin/changeRole")
+    public String changeUserRole(@RequestParam("userId") Long userId, @RequestParam("role") String role) {
+        adminService.changeUserRole(userId, role);
+        return "redirect:/admin";
+    }
+}

--- a/src/main/java/com/team25/backend/controller/AdminController.java
+++ b/src/main/java/com/team25/backend/controller/AdminController.java
@@ -1,0 +1,26 @@
+package com.team25.backend.controller;
+
+import com.team25.backend.dto.response.AdminPageResponse;
+import com.team25.backend.service.AdminService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@Controller
+public class AdminController {
+    private final AdminService adminService;
+
+    public AdminController(AdminService adminService) {
+        this.adminService = adminService;
+    }
+
+    @GetMapping("/admin")
+    public String showAdminPage(Model model) {
+        List<AdminPageResponse> usersWithManagers = adminService.getAllUsersWithManagers();
+        model.addAttribute("usersWithManagers", usersWithManagers);
+        return "admin/list";
+    }
+}
+

--- a/src/main/java/com/team25/backend/dto/response/AdminPageResponse.java
+++ b/src/main/java/com/team25/backend/dto/response/AdminPageResponse.java
@@ -1,0 +1,11 @@
+package com.team25.backend.dto.response;
+
+import java.util.List;
+
+public record AdminPageResponse(
+        Long userId,
+        String username,
+        String role,
+        String managerName,
+        List<String> certificates
+) {}

--- a/src/main/java/com/team25/backend/entity/User.java
+++ b/src/main/java/com/team25/backend/entity/User.java
@@ -40,4 +40,8 @@ public class User {
         this.role = role;
         this.uuid = uuid;
     }
+
+    public void updateRole(String role){
+        this.role = role;
+    }
 }

--- a/src/main/java/com/team25/backend/entity/User.java
+++ b/src/main/java/com/team25/backend/entity/User.java
@@ -28,6 +28,9 @@ public class User {
     @Column(name = "role")
     private String role;
 
+    // Manager와의 연관관계 추가
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Manager manager;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Reservation> reservations = new ArrayList<>();

--- a/src/main/java/com/team25/backend/repository/UserRepository.java
+++ b/src/main/java/com/team25/backend/repository/UserRepository.java
@@ -2,8 +2,10 @@ package com.team25.backend.repository;
 
 import com.team25.backend.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +13,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
     Optional<User> findByUuid(String uuid);
     Boolean existsByUsername(String username);
+
+    // Manager가 있는 User만 조회하는 JPQL 쿼리
+    @Query("SELECT u FROM User u WHERE u.manager IS NOT NULL")
+    List<User> findUsersWithManager();
 }

--- a/src/main/java/com/team25/backend/service/AdminService.java
+++ b/src/main/java/com/team25/backend/service/AdminService.java
@@ -2,11 +2,13 @@ package com.team25.backend.service;
 
 import com.team25.backend.dto.response.AdminPageResponse;
 import com.team25.backend.entity.Manager;
+import com.team25.backend.entity.User;
 import com.team25.backend.repository.UserRepository;
 import com.team25.backend.entity.Certificate;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -35,5 +37,13 @@ public class AdminService {
                 })
                 .collect(Collectors.toList());
     }
-}
 
+    public void changeUserRole(Long userId, String role) {
+        Optional<User> userOptional = userRepository.findById(userId);
+        if (userOptional.isPresent()) {
+            User user = userOptional.get();
+            user.updateRole(role);
+            userRepository.save(user);
+        }
+    }
+}

--- a/src/main/java/com/team25/backend/service/AdminService.java
+++ b/src/main/java/com/team25/backend/service/AdminService.java
@@ -1,0 +1,39 @@
+package com.team25.backend.service;
+
+import com.team25.backend.dto.response.AdminPageResponse;
+import com.team25.backend.entity.Manager;
+import com.team25.backend.repository.UserRepository;
+import com.team25.backend.entity.Certificate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class AdminService {
+    private final UserRepository userRepository;
+
+    public AdminService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public List<AdminPageResponse> getAllUsersWithManagers() {
+        return userRepository.findUsersWithManager().stream()
+                .map(user -> {
+                    Manager manager = user.getManager();
+                    List<String> certificateImages = manager.getCertificates().stream()
+                            .map(Certificate::getCertificateImage)
+                            .collect(Collectors.toList());
+
+                    return new AdminPageResponse(
+                            user.getId(),
+                            user.getUsername(),
+                            user.getRole(),
+                            manager.getManagerName(),
+                            certificateImages
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+}
+

--- a/src/main/resources/templates/admin/list.html
+++ b/src/main/resources/templates/admin/list.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Page</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body>
+<div class="container mt-5">
+    <h2>Admin Page</h2>
+    <table class="table table-bordered">
+        <thead>
+        <tr>
+            <th>User ID</th>
+            <th>Username</th>
+            <th>Role</th>
+            <th>Manager Name</th>
+            <th>Certificates</th>
+            <th>Change Role</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="user : ${usersWithManagers}">
+            <td th:text="${user.userId}"></td>
+            <td th:text="${user.username}"></td>
+            <td th:text="${user.role}"></td>
+            <td th:text="${user.managerName}"></td>
+            <td>
+                <ul>
+                    <li th:each="cert : ${user.certificates}" th:text="${cert}"></li>
+                </ul>
+            </td>
+            <td>
+                <!-- Change to MANAGER_ROLE -->
+                <form th:action="@{/admin/changeRole}" method="post">
+                    <input type="hidden" th:name="userId" th:value="${user.userId}"/>
+                    <input type="hidden" name="role" value="ROLE_MANAGER"/>
+                    <button type="submit" class="btn btn-primary">Change to MANAGER_ROLE</button>
+                </form>
+
+                <!-- Change to USER_ROLE -->
+                <form th:action="@{/admin/changeRole}" method="post" class="mt-2">
+                    <input type="hidden" th:name="userId" th:value="${user.userId}"/>
+                    <input type="hidden" name="role" value="ROLE_USER"/>
+                    <button type="submit" class="btn btn-secondary">Change to USER_ROLE</button>
+                </form>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 구현 기능
- 매니저로 등록된 회원 목록 조회
- 매니저로 등록된 회원 Role 변경 기능 (USER_ROLE, MANGER_ROLE 둘 중 선택가능)

## 변경점
- User와 Manger가 단방향 1:1 연관 관계 였는데 양방향으로 변경했습니다.

## 추가
- 중간고사 +  졸업 과제 마감 이슈로... 에러 핸들링이나 코드 리팩토링은 진행하지 못했습니다 ㅜㅜ
- S3를 이용한 사진 랜더링은 다음 주차에 진행해보도록 하겠습니다!